### PR TITLE
perf: batch internal async jobs + skip unobserved readable emissions

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -28,6 +28,102 @@ export function setTaskScheduler(scheduler: TaskScheduler): void {
   taskScheduler = scheduler;
 }
 
+// Internal job queue.
+//
+// Iterators frequently schedule small units of asynchronous work:
+// emitting a `readable` or `end` event, ending an iterator,
+// starting a buffer fill, etc.
+// Passing a fresh closure per unit of work to the task scheduler
+// is costly: every closure is an allocation,
+// and every `queueMicrotask` call internally allocates an `AsyncResource`.
+//
+// Instead, jobs are pushed as (iterator, jobKind) pairs
+// onto a shared queue that is drained by a single scheduled task.
+// Jobs run in exactly the order in which they were scheduled.
+// Jobs scheduled while the queue is draining
+// are processed in a follow-up task,
+// so the task scheduler's starvation protection remains effective.
+const JOB_EMITREADABLE = 0;
+const JOB_EMITEND = 1;
+const JOB_END = 2;
+const JOB_EMITDATA = 3;
+const JOB_INIT = 4;
+const JOB_FILLBUFFER = 5;
+
+const jobIterators: any[] = [];
+const jobKinds: number[] = [];
+let jobHead = 0;
+let jobDrainScheduled = false;
+
+function scheduleJob(iterator: any, kind: number): void {
+  jobIterators.push(iterator);
+  jobKinds.push(kind);
+  if (!jobDrainScheduled) {
+    jobDrainScheduled = true;
+    taskScheduler(drainJobs);
+  }
+}
+
+function runJob(iterator: any, kind: number): void {
+  switch (kind) {
+  case JOB_EMITREADABLE:
+    iterator._emitReadablePending = false;
+    iterator.emit('readable');
+    break;
+  case JOB_EMITEND:
+    iterator.emit('end');
+    break;
+  case JOB_END:
+    iterator._end();
+    break;
+  case JOB_EMITDATA:
+    emitData.call(iterator);
+    break;
+  case JOB_INIT:
+    iterator._init(iterator._initAutoStart);
+    break;
+  default:
+    iterator._reading = false;
+    iterator._fillBuffer();
+    break;
+  }
+}
+
+function drainJobs(): void {
+  // Unlock scheduling upfront, such that jobs scheduled by the jobs below
+  // claim a new drain task at their actual scheduling time.
+  // This keeps every job in submission order relative to
+  // any other tasks passed to the task scheduler.
+  jobDrainScheduled = false;
+  // Only process jobs that were queued before this drain started;
+  // jobs queued during this drain are processed by their own drain task
+  const count = jobIterators.length;
+  let i = jobHead;
+  try {
+    for (; i < count; i++) {
+      const iterator = jobIterators[i];
+      jobIterators[i] = null;
+      runJob(iterator, jobKinds[i]);
+    }
+  }
+  finally {
+    // Mark all jobs as processed, including a possibly throwing one
+    jobHead = i < count ? i + 1 : count;
+    // If all jobs have been processed, empty the queue;
+    // array truncation via `length` does not allocate, unlike `splice`
+    if (jobHead === jobIterators.length) {
+      jobIterators.length = 0;
+      jobKinds.length = 0;
+      jobHead = 0;
+    }
+    // If a job threw, ensure a drain task exists for unprocessed jobs
+    else if (!jobDrainScheduled) {
+      jobDrainScheduled = true;
+      taskScheduler(drainJobs);
+    }
+  }
+}
+
 
 /**
   ID of the INIT state.
@@ -83,6 +179,7 @@ export const DESTROYED = 1 << 5;
 export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   protected _state: number;
   private _readable = false;
+  protected _emitReadablePending = false;
   protected _properties?: { [name: string]: any };
   protected _propertyCallbacks?: { [name: string]: [(value: any) => void] };
 
@@ -90,7 +187,7 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   constructor(initialState = OPEN) {
     super();
     this._state = initialState;
-    this.on('newListener', waitForDataListener);
+    this.on('newListener', onNewListener);
   }
 
   /**
@@ -112,7 +209,7 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
         if (!eventAsync)
           this.emit('end');
         else
-          taskScheduler(() => this.emit('end'));
+          scheduleJob(this, JOB_EMITEND);
       }
     }
     return valid;
@@ -232,7 +329,7 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
     @protected
   */
   protected _endAsync() {
-    taskScheduler(() => this._end());
+    scheduleJob(this, JOB_END);
   }
 
   /**
@@ -256,9 +353,14 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
     // Set the readable value only if it has changed
     if (this._readable !== readable) {
       this._readable = readable;
-      // If the iterator became readable, emit the `readable` event
-      if (readable)
-        taskScheduler(() => this.emit('readable'));
+      // If the iterator became readable, emit the `readable` event.
+      // Without `readable` listeners, emission is skipped:
+      // a `readable` listener that is attached later
+      // is served by the `newListener` hook instead.
+      if (readable && this.listenerCount('readable') !== 0) {
+        this._emitReadablePending = true;
+        scheduleJob(this, JOB_EMITREADABLE);
+      }
     }
   }
 
@@ -641,13 +743,22 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   }
 }
 
-// Starts emitting `data` events when `data` listeners are added
-function waitForDataListener(this: AsyncIterator<any>, eventName: string) {
+// Reacts to listeners being attached to the iterator
+function onNewListener(this: AsyncIterator<any>, eventName: string, listener: (...args: any[]) => void) {
+  // Starts emitting `data` events when `data` listeners are added
   if (eventName === 'data') {
-    this.removeListener('newListener', waitForDataListener);
+    this.removeListener('newListener', onNewListener);
     addSingleListener(this, 'readable', emitData);
     if (this.readable)
-      taskScheduler(() => emitData.call(this));
+      scheduleJob(this, JOB_EMITDATA);
+  }
+  // Since `readable` events are only scheduled when listeners are present,
+  // an iterator that became readable earlier
+  // signals its readability to newly attached listeners
+  else if (eventName === 'readable' && listener !== emitData &&
+           this.readable && !(this as any)._emitReadablePending) {
+    (this as any)._emitReadablePending = true;
+    scheduleJob(this, JOB_EMITREADABLE);
   }
 }
 // Emits new items though `data` events as long as there are `data` listeners
@@ -659,7 +770,7 @@ function emitData(this: AsyncIterator<any>) {
   // Stop draining the source if there are no more `data` listeners
   if (this.listenerCount('data') === 0 && !this.done) {
     this.removeListener('readable', emitData);
-    addSingleListener(this, 'newListener', waitForDataListener);
+    addSingleListener(this, 'newListener', onNewListener);
   }
 }
 
@@ -978,6 +1089,7 @@ export class BufferedIterator<T> extends AsyncIterator<T> {
   protected _reading = true;
   protected _pushedCount = 0;
   protected _sourceStarted: boolean;
+  protected _initAutoStart = true;
 
   /**
     Creates a new `BufferedIterator`.
@@ -988,7 +1100,8 @@ export class BufferedIterator<T> extends AsyncIterator<T> {
   constructor({ maxBufferSize = 4, autoStart = true }: BufferedIteratorOptions = {}) {
     super(INIT);
     this.maxBufferSize = maxBufferSize;
-    taskScheduler(() => this._init(autoStart));
+    this._initAutoStart = autoStart;
+    scheduleJob(this, JOB_INIT);
     this._sourceStarted = autoStart !== false;
   }
 
@@ -1166,14 +1279,11 @@ export class BufferedIterator<T> extends AsyncIterator<T> {
     Schedules `_fillBuffer` asynchronously.
   */
   protected _fillBufferAsync() {
-    // Acquire reading lock to avoid recursive reads
+    // Acquire reading lock to avoid recursive reads;
+    // the scheduled job releases the lock and calls `_fillBuffer`
     if (!this._reading) {
       this._reading = true;
-      taskScheduler(() => {
-        // Release reading lock so _fillBuffer` can take it
-        this._reading = false;
-        this._fillBuffer();
-      });
+      scheduleJob(this, JOB_FILLBUFFER);
     }
   }
 

--- a/test/AsyncIterator-test.js
+++ b/test/AsyncIterator-test.js
@@ -1453,20 +1453,38 @@ describe('AsyncIterator', () => {
 });
 
 describe('The internal job queue', () => {
-  function trapUncaughtException(expectedError, done) {
-    const listeners = process.listeners('uncaughtException');
+  // Temporarily traps the error of a throwing scheduled job.
+  // Depending on how the task scheduler defers tasks,
+  // such an error surfaces as an uncaught exception
+  // (queueMicrotask or setImmediate schedulers)
+  // or as an unhandled promise rejection
+  // (the promise-based fallback on Node 10, which lacks queueMicrotask).
+  function trapJobError(expectedError, done) {
+    const exceptionListeners = process.listeners('uncaughtException');
+    const rejectionListeners = process.listeners('unhandledRejection');
     process.removeAllListeners('uncaughtException');
-    process.once('uncaughtException', error => {
-      for (const listener of listeners)
-        process.on('uncaughtException', listener);
-      try {
-        error.should.equal(expectedError);
-        done();
+    process.removeAllListeners('unhandledRejection');
+    let trapped = false;
+    function onJobError(error) {
+      if (!trapped) {
+        trapped = true;
+        process.removeListener('uncaughtException', onJobError);
+        process.removeListener('unhandledRejection', onJobError);
+        for (const listener of exceptionListeners)
+          process.on('uncaughtException', listener);
+        for (const listener of rejectionListeners)
+          process.on('unhandledRejection', listener);
+        try {
+          error.should.equal(expectedError);
+          done();
+        }
+        catch (assertionError) {
+          done(assertionError);
+        }
       }
-      catch (assertionError) {
-        done(assertionError);
-      }
-    });
+    }
+    process.on('uncaughtException', onJobError);
+    process.on('unhandledRejection', onJobError);
   }
 
   describe('when an event handler of a scheduled job throws', () => {
@@ -1478,7 +1496,7 @@ describe('The internal job queue', () => {
       first.on('end', () => { throw jobError; });
       second.on('end', () => { secondEnded = true; });
 
-      trapUncaughtException(jobError, error => {
+      trapJobError(jobError, error => {
         if (error) {
           done(error);
           return;
@@ -1511,7 +1529,7 @@ describe('The internal job queue', () => {
         throw jobError;
       });
 
-      trapUncaughtException(jobError, error => {
+      trapJobError(jobError, error => {
         if (error) {
           done(error);
           return;

--- a/test/AsyncIterator-test.js
+++ b/test/AsyncIterator-test.js
@@ -1452,6 +1452,86 @@ describe('AsyncIterator', () => {
   });
 });
 
+describe('The internal job queue', () => {
+  function trapUncaughtException(expectedError, done) {
+    const listeners = process.listeners('uncaughtException');
+    process.removeAllListeners('uncaughtException');
+    process.once('uncaughtException', error => {
+      for (const listener of listeners)
+        process.on('uncaughtException', listener);
+      try {
+        error.should.equal(expectedError);
+        done();
+      }
+      catch (assertionError) {
+        done(assertionError);
+      }
+    });
+  }
+
+  describe('when an event handler of a scheduled job throws', () => {
+    it('still executes jobs that were already scheduled', done => {
+      const first = new AsyncIterator();
+      const second = new AsyncIterator();
+      const jobError = new Error('job error');
+      let secondEnded = false;
+      first.on('end', () => { throw jobError; });
+      second.on('end', () => { secondEnded = true; });
+
+      trapUncaughtException(jobError, error => {
+        if (error) {
+          done(error);
+          return;
+        }
+        // The end of the second iterator must still be processed
+        scheduleTask(() => scheduleTask(() => {
+          try {
+            secondEnded.should.equal(true);
+            done();
+          }
+          catch (assertionError) {
+            done(assertionError);
+          }
+        }));
+      });
+
+      first.close();
+      second.close();
+    });
+
+    it('still executes jobs that the throwing job scheduled', done => {
+      const first = new AsyncIterator();
+      const second = new AsyncIterator();
+      const jobError = new Error('job error');
+      let secondEnded = false;
+      second.on('end', () => { secondEnded = true; });
+      first.on('end', () => {
+        // Schedule another job before throwing
+        second.close();
+        throw jobError;
+      });
+
+      trapUncaughtException(jobError, error => {
+        if (error) {
+          done(error);
+          return;
+        }
+        scheduleTask(() => scheduleTask(() => {
+          try {
+            secondEnded.should.equal(true);
+            done();
+          }
+          catch (assertionError) {
+            done(assertionError);
+          }
+        }));
+      });
+
+      first.close();
+    });
+  });
+});
+
 describe('Type-checking functions', () => {
   describe('isPromise', () => {
     it('returns false for null', () => {


### PR DESCRIPTION
## Summary

Two changes to how iterators schedule internal asynchronous work, adapted from the custom scheduler in @jeswr's rewrite attempt ([jeswr/temp-asyncit](https://github.com/jeswr/temp-asyncit), `V5/src/iteratorTask/sync.ts` + `V5/Writeup.md` "Custom Scheduling"):

**1. Shared internal job queue.** Emitting `readable`/`end`, ending an iterator, starting a buffer fill, and initializing a `BufferedIterator` were each scheduled as a fresh closure through the task scheduler. Every closure is an allocation, and every `queueMicrotask()` call internally allocates an `AsyncResource` (visible in CPU profiles as ~20–25% of TransformIterator pipelines: `enqueueMicrotask`, `AsyncResource`, `runInAsyncScope`, `emitDestroyScript`). Jobs are now pushed as `(iterator, jobKind)` pairs onto a shared queue drained by a single scheduled task.

Ordering is preserved exactly: a drain task is claimed through the (still pluggable) task scheduler at first-job submission time — including for jobs submitted *during* a drain — so every job keeps its submission-order slot relative to any other `scheduleTask()` tasks. The queue is consumed by index with `length = 0` truncation (no `splice` allocations), and a throwing job (e.g. a throwing `end` handler) does not prevent later jobs from running (covered by two new tests).

**2. `readable` emissions only when observable.** `readable = true` used to schedule an emission even with no `readable` listener attached — notably at construction, where no listener can possibly exist yet, so every `ArrayIterator`/`IntegerIterator`/`SingletonIterator` constructor paid a scheduled task + emission into the void. Emission is now scheduled only when `readable` listeners are present; a `readable` listener attached while the iterator is already readable is served through the `newListener` hook (deduplicated via a pending flag).

`getTaskScheduler`/`setTaskScheduler`/`scheduleTask` semantics are unchanged; both test scheduler modes pass.

## Behavioral notes (superset, flagged for review)

- A `readable` listener attached *after* the iterator became readable now reliably receives a `readable` event; previously the emission could already have fired with no listeners and the late subscriber got nothing until the next `false→true` transition. This matches the semantics @jeswr specified in his rewrite's writeup ("emit the tick after a `readable` listener is attached if the iterator is readable") and is strictly easier to consume correctly.
- `BufferedIterator` initialization is scheduled as a job with the `autoStart` flag stored on the instance (`_initAutoStart`) instead of captured in a closure.

## Measurements

Node v22.23.1, Linux x86_64 (2-core shared host, `nice -n 18`), 7 alternating A/B process runs per side, medians; ratios are the signal.

| scenario | base wall (ms) | PR wall (ms) | wall ratio | cpu ratio |
|---|---|---|---|---|
| 200k × `new ArrayIterator([4 items])` + destroy | 1154.5 | 259.5 | **0.22** | **0.18** |
| `.transform({map, offset, limit})` 100k items | 75.6 | 49.8 | **0.66** | 0.59 |
| 200k items `for await` | 69.2 | 57.5 | **0.83** | 0.86 |
| 100k items × 10 chained `.map()` | 88.9 | 76.9 | 0.87 | 0.91 |
| 100k items × 5 `.map()` + 5 `.filter()` | 58.6 | 54.3 | 0.93 | 0.87 |
| TransformIterator 50k items | 83.8 | 75.8 | 0.90 | 0.97 |
| 30k short-lived `.map` pipelines | 245.7 | 221.6 | **0.90** | 0.91 |
| 2-way `.clone()` of 100k items | 55.0 | 46.8 | 0.85 | 0.86 |
| UnionIterator 8×25k | 106.2 | 103.4 | 0.97 | 0.94 |
| 1M items `data` flow drain | 131.6 | 129.0 | 0.98 | 1.00 |

Construction is the headline: the prior program's microbenchmarks measured `new ArrayIterator([1,2,3,4])` at ~1027ns — ~7.4× a bare Node `Readable` — with 2 of its 5 lifecycle scheduler tasks spent at construction time. This PR removes both construction-time tasks.

## Relation to @jeswr's rewrite attempt

Adopted/adapted:
- The deduplicated global queue design (his `READABLE_QUEUE`/`ITEM_GENERATION_QUEUE`/`DATA_EMIT_QUEUE`) — collapsed here into one kind-tagged queue to preserve upstream's strict cross-kind FIFO ordering.
- Emit-`readable`-on-listener-attach semantics (his `newListener` emitter).
- "Don't announce readable on start" (also independently prototyped by @RubenVerborgh in the fork's 2020 `feature/performance` branch: "Do not announce readable on start").

Not adopted:
- His three separate queues with per-queue priorities: cross-kind FIFO is load-bearing for the current test suite's tick-level expectations.
- Sync-vs-async scheduling modes (his Writeup §"sync vs. async scheduling"): out of scope for a drop-in PR; the pluggable task scheduler already covers part of this.
- End-only-during-read semantics: breaking; deferred.

## Tests

Full suite passes in both scheduler modes (microtask + setImmediate); coverage 100/100/100/100. Two new tests cover job-queue robustness when event handlers throw.

**Node 10 note:** Node 10 lacks `queueMicrotask`, so the task scheduler defers through its promise fallback (`resolved.then(task)`) there; an error thrown from a scheduled job then surfaces as an `unhandledRejection` instead of an `uncaughtException`. The queue's recovery behavior is identical on all supported Node versions (10-22, per the CI matrix); the two new tests trap both channels accordingly. Verified with the full suite on Node 10.24.1.


## Real-workload relevance

In a Comunica WatDiv mixed-workload CPU profile (real downstream consumer; asynciterator ~9.5% of total self time), the sites this PR targets are the #3–#8 asynciterator entries: `set readable` (0.47%), the `_endAsync`/emit closures at asynciterator.js:211/:234 (0.26%/0.17%), `_fillBuffer` (0.35%), and `_changeState` (0.17%).
---
*This PR was generated by an agent (Claude Fable 5) on @jeswr's behalf, as part of a measured performance pass over asynciterator. All numbers above were produced on-box with the stated methodology.*



> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).

