### PR TITLE
perf: fuse chains of synchronous map/filter transformations

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -890,12 +890,23 @@ export const DESTINATION = Symbol('destination');
 /**
  An iterator that synchronously transforms every item from its source
  by applying a mapping function.
+ Chains of synchronous transformations are fused:
+ when a `MappingIterator` is mapped or filtered again,
+ the resulting iterator reads directly from the root source
+ and applies all transformation functions in one call,
+ instead of performing a chain of nested `read` calls.
+ The intermediate iterators remain part of the pipeline
+ for event and lifecycle propagation
+ (`end`, `error`, destruction, and `destroySource` behavior).
  @extends module:asynciterator.AsyncIterator
 */
 export class MappingIterator<S, D = S> extends AsyncIterator<D> {
   protected readonly _map: MapFunction<S, D>;
   protected readonly _source: InternalSource<S>;
   protected readonly _destroySource: boolean;
+  protected readonly _root: InternalSource<any>;
+  protected readonly _chainMaps: MapFunction<any, any>[];
+  protected readonly _chainOwners: AsyncIterator<any>[];
 
   /**
    * Applies the given mapping to the source iterator.
@@ -909,6 +920,23 @@ export class MappingIterator<S, D = S> extends AsyncIterator<D> {
     this._map = map;
     this._source = ensureSourceAvailable(source);
     this._destroySource = options.destroySource !== false;
+
+    // If the source is a mapping iterator with the default read behavior,
+    // fuse both synchronous transformations into a single chain
+    // that reads straight from the root source
+    if (source instanceof MappingIterator &&
+        (source as any).read === MappingIterator.prototype.read &&
+        this.read === MappingIterator.prototype.read) {
+      this._root = source._root;
+      this._chainMaps = [...source._chainMaps, map];
+      this._chainOwners = [...source._chainOwners, this];
+    }
+    // Otherwise, this iterator starts a new chain
+    else {
+      this._root = this._source;
+      this._chainMaps = [map];
+      this._chainOwners = [this];
+    }
 
     // Close if the source is already empty
     if (source.done) {
@@ -928,14 +956,28 @@ export class MappingIterator<S, D = S> extends AsyncIterator<D> {
   read(): D | null {
     if (!this.done) {
       // Try to read an item that maps to a non-null value
-      if (this._source.readable) {
-        let item: S | null, mapped: D | null;
-        while ((item = this._source.read()) !== null) {
-          if ((mapped = this._map(item)) !== null)
-            return mapped;
+      const root = this._root;
+      if (root.readable) {
+        const maps = this._chainMaps, owners = this._chainOwners, { length } = maps;
+        let item: any;
+        while ((item = root.read()) !== null) {
+          // Apply all transformations of the fused chain,
+          // with each function bound to the iterator that created it
+          for (let i = 0; i < length && item !== null; i++)
+            item = maps[i].call(owners[i], item);
+          if (item !== null)
+            return item;
         }
       }
-      this.readable = false;
+      // Mark every iterator of the fused chain as drained,
+      // exactly as a chain of nested read() calls would have.
+      // In particular, intermediate iterators must become unreadable:
+      // otherwise, a later readable signal from the root
+      // would be swallowed by their unchanged readable state,
+      // and never reach the consumers of this iterator.
+      const owners = this._chainOwners;
+      for (let i = 0; i < owners.length; i++)
+        owners[i].readable = false;
 
       // Close this iterator if the source is empty
       if (this._source.done)

--- a/test/MappingIterator-test.js
+++ b/test/MappingIterator-test.js
@@ -1047,3 +1047,44 @@ describe('MappingIterator', () => {
     });
   });
 });
+
+describe('MappingIterator fused chains', () => {
+  describe('when the root becomes readable again after the chain drained', () => {
+    it('wakes up consumers of the outermost iterator', done => {
+      const root = new AsyncIterator();
+      let buffer = [1, 2];
+      root.read = function () {
+        if (buffer.length === 0) {
+          this.readable = false;
+          return null;
+        }
+        return buffer.shift();
+      };
+      root.readable = true;
+
+      const mapped = root.map(x => x * 10).map(x => x + 1);
+
+      // Drain all currently available items
+      const collected = [];
+      let item;
+      while ((item = mapped.read()) !== null)
+        collected.push(item);
+      collected.should.deep.equal([11, 21]);
+
+      // The `readable` event must reach the outermost iterator,
+      // even though the intermediate iterator is bypassed by fusion
+      mapped.on('readable', () => {
+        const value = mapped.read();
+        if (value !== null) {
+          value.should.equal(31);
+          mapped.destroy();
+          done();
+        }
+      });
+
+      // Make new items available on the root
+      buffer = [3];
+      root.readable = true;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fuses chains of synchronous transformations. `source.map(f).filter(p).map(g)` used to be a chain of three `MappingIterator`s where every item passed through three nested `read()` calls, each with its own `done`/`readable` checks and dynamic dispatch. The outermost iterator now reads **directly from the root source** and applies all transformation functions of the chain in one loop.

Since `filter()`, `skip()`, and `uniq()` are implemented on top of `map()`, they participate in fusion automatically.

## Design (and why it stays compatible)

This is the compatibility-preserving adaptation of the `CompositeMappingIterator` from @jeswr's rewrite attempt ([jeswr/temp-asyncit](https://github.com/jeswr/temp-asyncit) `V4`/`V5`) and the fork's earlier `jeswr/faster-filtering-mapping` branch (`MultiMapFilterTransformIterator`, commit 1ec39fb):

- Each `MappingIterator` carries `_root` (the ultimate non-mapping source), `_chainMaps` (all functions so far), and `_chainOwners` (the iterator that contributed each function).
- **The intermediate iterators stay wired exactly as today** (`DESTINATION` link, `end`/`error`/`readable` listeners). Only the *read path* is fused; `end` cascades, error propagation, destruction order, and per-stage `destroySource` options are byte-for-byte the same code path as before. (His V5 uses the same hybrid: chain kept for lifecycle, reads bypass it.)
- Each function is invoked with `this` bound to the iterator that created it (`maps[i].call(owners[i], item)`), preserving the documented callback `this` semantics that the test suite asserts (`map.alwaysCalledOn(...)`).
- Fusion is **only** applied when neither the source nor the new iterator overrides `MappingIterator#read`, so subclasses with custom read behavior are never bypassed.

Reading an intermediate iterator of a fused chain still "steals" items from the pipeline, same as today; the docs already state that after `.map()` "only read the returned iterator instead of the current one".

## Measurements

Node v22.23.1, Linux x86_64 (2-core shared host, `nice -n 18`), 7 alternating A/B process runs per side, medians; ratios are the signal.

| scenario | base wall (ms) | PR wall (ms) | wall ratio | cpu ratio |
|---|---|---|---|---|
| 100k items × 10 chained `.map()` | 91.2 | 31.8 | **0.35** | 0.42 |
| 100k items × 5 `.map()` + 5 `.filter()` | 64.7 | 25.9 | **0.40** | 0.42 |
| UnionIterator 8×25k | 110.0 | 100.8 | 0.92 | 0.91 |
| 1M items `readable`/`read()` loop | 62.6 | 60.4 | 0.97 | 0.91 |
| 30k short-lived `.map` pipelines | 249.8 | 257.5 | 1.03 | 1.03 |
| 200k × ctor+destroy / flow / for-await / MultiTransform | — | — | 0.97–1.08 | ≈1 |

The single-stage scenarios sit within this box's noise band (±5–8%); the chained scenarios are the target and reproduce stably (also on upstream's own `perf/MappingIterator-perf.js`, which is exactly the 20-maps shape). The ~3% on 30k short-lived pipelines is the cost of two small per-iterator arrays; if that matters for review, a lazy single-stage representation is possible at the cost of a branchier `read()`.

Note: the upstream baseline for chained maps improves dramatically on its own once the `delete`-deopt fix (PR #2) lands — these two PRs compose; the fusion win here is measured against unpatched main and remains a further ~2× on top of #2 in combined runs.

## Relation to @jeswr's rewrite attempt

Adopted/adapted:
- Read-from-root fused chain (`CompositeMappingIterator`, V4/V5), including his hybrid of keeping the source chain for lifecycle while bypassing it for reads.
- Function-array representation (V4) rather than nested composed closures (his 2022 branch tried both).

Not adopted:
- Rebasing `filter`/`skip`/`take` onto dedicated iterator classes (his `FilteringIterator`/`SkippingIterator`/`LimitingIterator`): upstream has since standardized on `map`-based composition, which fusion now serves equally well.
- His V5 requirement that sources must always be wrapped before transforming (error-forwarding redesign): breaking, out of scope.

## Integration verification (Comunica)

Running Comunica (`query-sparql-file`, monorepo checkout) against this branch surfaced a real bug in the first version of this PR: with a fused chain, the *intermediate* iterators were never read, so their `readable` flag stayed `true`; a later `readable` signal from the root was then swallowed by their unchanged state (the `readable = true` setter is a no-op when already readable) and never reached consumers — single-pattern SPARQL queries hung. The fix marks every iterator of the fused chain unreadable on a drained read, exactly as nested reads would have; a regression test covers the wakeup path. After the fix, a join+union+filter query over 140k triples returns identical results (68,320 bindings) on this branch and on `main`.

## Tests

Full suite passes in both scheduler modes; coverage 100/100/100/100. No test changes were needed — lifecycle, error, destroy-propagation, and `this`-binding tests all pass unmodified.

---
*This PR was generated by an agent (Claude Fable 5) on @jeswr's behalf, as part of a measured performance pass over asynciterator. All numbers above were produced on-box with the stated methodology.*

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).
