### PR TITLE
perf: flow-mode flag + synchronous fast path for ES async iteration (stacked on #3)

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -180,6 +180,7 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   protected _state: number;
   private _readable = false;
   protected _emitReadablePending = false;
+  protected _flowing = false;
   protected _properties?: { [name: string]: any };
   protected _propertyCallbacks?: { [name: string]: [(value: any) => void] };
 
@@ -318,6 +319,12 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   protected _end(destroy = false) {
     if (this._changeState(destroy ? DESTROYED : ENDED)) {
       this._readable = false;
+      // Detach the flow-mode bookkeeping hook first,
+      // so the removals below do not emit `removeListener` events
+      if (this._flowing) {
+        this._flowing = false;
+        this.removeListener('removeListener', onRemoveDataListener);
+      }
       this.removeAllListeners('readable');
       this.removeAllListeners('data');
       this.removeAllListeners('end');
@@ -733,6 +740,28 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
     // An EcmaScript AsyncIterator exposes the next() function that can be invoked repeatedly
     return {
       next(): Promise<IteratorResult<T>> {
+        // If no read is pending, try to settle synchronously available results
+        // through already-resolved promises,
+        // avoiding the allocation of a promise executor and its closures
+        if (currentResolve === null) {
+          // Reject with an error that arrived while no read was pending
+          if (pendingError !== null) {
+            const error = pendingError;
+            pendingError = null;
+            removeListeners();
+            return Promise.reject(error);
+          }
+          // Signal the end of the iterator
+          if (it.done) {
+            removeListeners();
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          // Emit an item that is synchronously available
+          const value = it.read();
+          if (value !== null)
+            return Promise.resolve({ done: false, value });
+        }
+        // Await the next item, end, or error asynchronously
         return new Promise<IteratorResult<T>>((resolve, reject) => {
           currentResolve = resolve;
           currentReject = reject;
@@ -748,7 +777,12 @@ function onNewListener(this: AsyncIterator<any>, eventName: string, listener: (.
   // Starts emitting `data` events when `data` listeners are added
   if (eventName === 'data') {
     this.removeListener('newListener', onNewListener);
+    (this as any)._flowing = true;
     addSingleListener(this, 'readable', emitData);
+    // The hook cannot be attached twice:
+    // flow mode is only entered through this listener,
+    // which is only re-armed after the hook has been removed
+    this.on('removeListener', onRemoveDataListener);
     if (this.readable)
       scheduleJob(this, JOB_EMITDATA);
   }
@@ -761,17 +795,26 @@ function onNewListener(this: AsyncIterator<any>, eventName: string, listener: (.
     scheduleJob(this, JOB_EMITREADABLE);
   }
 }
-// Emits new items though `data` events as long as there are `data` listeners
-function emitData(this: AsyncIterator<any>) {
-  // While there are `data` listeners and items, emit them
-  let item;
-  while (this.listenerCount('data') !== 0 && (item = this.read()) !== null)
-    this.emit('data', item);
-  // Stop draining the source if there are no more `data` listeners
-  if (this.listenerCount('data') === 0 && !this.done) {
+// Reacts to `data` listeners being removed from the iterator:
+// when the last one is removed, the iterator leaves flow mode
+function onRemoveDataListener(this: AsyncIterator<any>, eventName: string) {
+  if (eventName === 'data' && (this as any)._flowing &&
+      this.listenerCount('data') === 0) {
+    (this as any)._flowing = false;
     this.removeListener('readable', emitData);
-    addSingleListener(this, 'newListener', onNewListener);
+    this.removeListener('removeListener', onRemoveDataListener);
+    // Wait for `data` listeners again, unless the iterator has ended
+    if (!this.done)
+      addSingleListener(this, 'newListener', onNewListener);
   }
+}
+
+// Emits new items though `data` events as long as the iterator is in flow mode.
+// The `_flowing` flag replaces a `listenerCount('data')` call per emitted item.
+function emitData(this: AsyncIterator<any>) {
+  let item;
+  while ((this as any)._flowing && (item = this.read()) !== null)
+    this.emit('data', item);
 }
 
 // Adds the listener to the event, if it has not been added previously.


### PR DESCRIPTION
## Summary

**Stacked on #3** (`perf/lazy-readable-scheduling`) — this PR's base branch is set accordingly, so the diff shows only its own changes. Merge #3 first.

Optimizes the two main consumption styles:

**1. Flow mode tracked by a `_flowing` flag.** `emitData` called `listenerCount('data')` for **every emitted item** (6–7% of self time in a 1M-item flow profile). The flag is set when the first `data` listener attaches and cleared through a `removeListener` hook when the last one is removed. Leaving flow mode is now eager rather than lazily detected at the next drain attempt — with one deliberate consequence: re-attaching a `data` listener resumes flow immediately (via the re-armed `newListener` hook) instead of waiting for the next `readable` event. The hook is detached at the start of `_end`, so teardown listener removals don't emit `removeListener` events (this mattered: without it, short-lived pipelines regressed ~5–10%; with it they are at parity).

**2. Synchronous fast path for ES async iteration.** `next()` allocated a promise executor plus resolver closures for every item, even when an item was synchronously available. It now settles synchronously available results — pending error, iterator end, or a readable item — via `Promise.resolve`/`Promise.reject` directly. The listener-based waiting path is unchanged and only used when `read()` returns `null`. Error semantics (pending error captured between `next()` calls, rejection order before end) are preserved.

## Measurements

Node v22.23.1, Linux x86_64 (2-core shared host, `nice -n 18`), alternating paired process runs, medians, **relative to the #3 branch this builds on**. This box has a ±5–8% noise band (a live server shares the 2 cores); scenarios below the band are reported as parity.

| scenario | base wall (ms) | PR wall (ms) | wall ratio | cpu ratio |
|---|---|---|---|---|
| 200k items `for await` | 61.3 | 51.4 | **0.84** | **0.64** |
| 1M items `data` flow drain | 137.0 | 114.9 | **0.83** | 0.83 |
| `wrap()` of a 500k-item generator | 62.4 | 52.4 | **0.84** | 0.86 |
| 2-way `.clone()` of 100k items | 50.2 | 45.3 | 0.90 | 0.92 |
| TransformIterator 50k items (11-rep targeted run) | 88.2 | 80.6 | 0.91 | 0.94 |
| 30k short-lived `.map` pipelines | 248.0 | 246.3 | ≈1 | ≈1 |
| 200k × ctor+destroy | 272.8 | 264.0 | ≈1 | ≈1 |
| chained map/filter, union, MultiTransform | — | — | ≈1 | ≈1 |

(`for await` cpu 0.64 and flow 0.83 reproduced across 3 independent runs; transform50k is the noisiest scenario on this box, hence the dedicated 11-rep paired run.)

Combined with #2 + #3, `for await` over 200k items goes from ~66ms/76ms-cpu on unpatched main to ~46–51ms/47–49ms-cpu — roughly cutting the documented "for-await is the slow path" penalty in half.

## Behavioral notes (flagged for review)

- Re-attaching a `data` listener after removing all of them resumes flow immediately; previously flow resumed at the next `readable` emission. The existing suite's listener add/remove/re-add tests pass unchanged (same read counts, same listener-count assertions).
- One additional boolean field per iterator (`_flowing`) and one `removeListener` hook while in flow mode.

## Relation to @jeswr's rewrite attempt

Adopted/adapted from [jeswr/temp-asyncit](https://github.com/jeswr/temp-asyncit) V5:
- The `FLOWING` instance flag with `newListener`/`removeListener`-driven mode switching (`emitters/newListener.ts`, `emitData.ts`).
- The principle that the drain loop should test a boolean, not query the listener table per item.

Not adopted:
- His `DATA_EMIT_QUEUE` global queue for flow kick-off — #3's job queue already covers that role.
- His V5 `Symbol.asyncIterator` (destination-slot + promise-per-wait design) — it conflicts with allowing other destinations and with current error semantics; instead the existing listener protocol got a sync fast path.

## Tests

Full suite passes in both scheduler modes; coverage 100/100/100/100. No test changes needed.


## Real-workload relevance

Comunica consumes bindings streams through `data` listeners (flow mode) across every query operator, and the WatDiv mixed-workload profile shows the flow/emit machinery among the top asynciterator sites; the for-await fast path additionally serves the public query-result API surface (`bindingsStream` as async iterable).

**Update:** rebased on #3's head to inherit its Node 10 test fix (job-error trap covering `unhandledRejection`, since Node 10 lacks `queueMicrotask`); full suite verified on Node 10.24.1 and Node 22 (both scheduler modes, 100% coverage).

---
*This PR was generated by an agent (Claude Fable 5) on @jeswr's behalf, as part of a measured performance pass over asynciterator. All numbers above were produced on-box with the stated methodology.*

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).


