### PR TITLE
perf: avoid an object allocation on every setProperty call

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -382,19 +382,23 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   setProperty<P>(propertyName: string, value: P) {
     const properties = this._properties || (this._properties = Object.create(null));
     properties[propertyName] = value;
-    // Execute getter callbacks that were waiting for this property to be set
-    const propertyCallbacks = this._propertyCallbacks || {};
-    const callbacks = propertyCallbacks[propertyName];
-    if (callbacks) {
-      delete propertyCallbacks[propertyName];
-      taskScheduler(() => {
-        for (const callback of callbacks)
-          callback(value);
-      });
-      // Remove _propertyCallbacks if no pending callbacks are left
-      for (propertyName in propertyCallbacks)
-        return;
-      delete this._propertyCallbacks;
+    // Execute getter callbacks that were waiting for this property to be set;
+    // note that `_propertyCallbacks` is only checked, not allocated,
+    // as this is a hot path for iterators carrying metadata
+    const propertyCallbacks = this._propertyCallbacks;
+    if (propertyCallbacks) {
+      const callbacks = propertyCallbacks[propertyName];
+      if (callbacks) {
+        delete propertyCallbacks[propertyName];
+        taskScheduler(() => {
+          for (const callback of callbacks)
+            callback(value);
+        });
+        // Remove _propertyCallbacks if no pending callbacks are left
+        for (propertyName in propertyCallbacks)
+          return;
+        delete this._propertyCallbacks;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

`setProperty` allocated an empty fallback object on every call via `this._propertyCallbacks || {}` — purely to make the subsequent lookup safe, including in the overwhelmingly common case where no property callback is pending. The callback table is now only checked, never allocated.

## Motivation: real-workload profile

In a Comunica WatDiv mixed-workload CPU profile (asynciterator accounts for ~9.5% of total self time), `setProperty` is the **single largest asynciterator site** at 1.15% of total self time — Comunica attaches `metadata` properties to nearly every iterator it creates — and GC from short-lived allocations is the dominant overhead category of that workload (~26%). One guaranteed garbage object per `setProperty` call is exactly that category.

## Measurements

Node v22.23.1, isolated microbench (one iterator, 8M `setProperty` calls over 4 rotating property names, 3 paired runs):

| | base | this PR |
|---|---|---|
| ns/call (wall) | 49.6–52.8 | **25.3–34.0** |
| ns/call (cpu) | 49.9–53.0 | **25.5–29.9** |

≈1.9× faster per call, one fewer allocation per call.

## Compatibility

No observable behavior change; the callback-delivery path is identical. Full test suite passes in both scheduler modes, coverage 100/100/100/100.

## Relation to @jeswr's rewrite attempt

None — profile-guided find on the current codebase (the rewrite kept the same properties API shape).

---
*This PR was generated by an agent (Claude Fable 5) on @jeswr's behalf, as part of a measured performance pass over asynciterator. All numbers above were produced on-box with the stated methodology.*

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).
