### PR TITLE
perf rollup: combined branch of #2 #3 #4 #5 #6 (integration testing only)

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -382,19 +382,23 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   setProperty<P>(propertyName: string, value: P) {
     const properties = this._properties || (this._properties = Object.create(null));
     properties[propertyName] = value;
-    // Execute getter callbacks that were waiting for this property to be set
-    const propertyCallbacks = this._propertyCallbacks || {};
-    const callbacks = propertyCallbacks[propertyName];
-    if (callbacks) {
-      delete propertyCallbacks[propertyName];
-      taskScheduler(() => {
-        for (const callback of callbacks)
-          callback(value);
-      });
-      // Remove _propertyCallbacks if no pending callbacks are left
-      for (propertyName in propertyCallbacks)
-        return;
-      delete this._propertyCallbacks;
+    // Execute getter callbacks that were waiting for this property to be set;
+    // note that `_propertyCallbacks` is only checked, not allocated,
+    // as this is a hot path for iterators carrying metadata
+    const propertyCallbacks = this._propertyCallbacks;
+    if (propertyCallbacks) {
+      const callbacks = propertyCallbacks[propertyName];
+      if (callbacks) {
+        delete propertyCallbacks[propertyName];
+        taskScheduler(() => {
+          for (const callback of callbacks)
+            callback(value);
+        });
+        // Remove _propertyCallbacks if no pending callbacks are left
+        for (propertyName in propertyCallbacks)
+          return;
+        delete this._propertyCallbacks;
+      }
     }
   }
 

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -28,6 +28,102 @@ export function setTaskScheduler(scheduler: TaskScheduler): void {
   taskScheduler = scheduler;
 }
 
+// Internal job queue.
+//
+// Iterators frequently schedule small units of asynchronous work:
+// emitting a `readable` or `end` event, ending an iterator,
+// starting a buffer fill, etc.
+// Passing a fresh closure per unit of work to the task scheduler
+// is costly: every closure is an allocation,
+// and every `queueMicrotask` call internally allocates an `AsyncResource`.
+//
+// Instead, jobs are pushed as (iterator, jobKind) pairs
+// onto a shared queue that is drained by a single scheduled task.
+// Jobs run in exactly the order in which they were scheduled.
+// Jobs scheduled while the queue is draining
+// are processed in a follow-up task,
+// so the task scheduler's starvation protection remains effective.
+const JOB_EMITREADABLE = 0;
+const JOB_EMITEND = 1;
+const JOB_END = 2;
+const JOB_EMITDATA = 3;
+const JOB_INIT = 4;
+const JOB_FILLBUFFER = 5;
+
+const jobIterators: any[] = [];
+const jobKinds: number[] = [];
+let jobHead = 0;
+let jobDrainScheduled = false;
+
+function scheduleJob(iterator: any, kind: number): void {
+  jobIterators.push(iterator);
+  jobKinds.push(kind);
+  if (!jobDrainScheduled) {
+    jobDrainScheduled = true;
+    taskScheduler(drainJobs);
+  }
+}
+
+function runJob(iterator: any, kind: number): void {
+  switch (kind) {
+  case JOB_EMITREADABLE:
+    iterator._emitReadablePending = false;
+    iterator.emit('readable');
+    break;
+  case JOB_EMITEND:
+    iterator.emit('end');
+    break;
+  case JOB_END:
+    iterator._end();
+    break;
+  case JOB_EMITDATA:
+    emitData.call(iterator);
+    break;
+  case JOB_INIT:
+    iterator._init(iterator._initAutoStart);
+    break;
+  default:
+    iterator._reading = false;
+    iterator._fillBuffer();
+    break;
+  }
+}
+
+function drainJobs(): void {
+  // Unlock scheduling upfront, such that jobs scheduled by the jobs below
+  // claim a new drain task at their actual scheduling time.
+  // This keeps every job in submission order relative to
+  // any other tasks passed to the task scheduler.
+  jobDrainScheduled = false;
+  // Only process jobs that were queued before this drain started;
+  // jobs queued during this drain are processed by their own drain task
+  const count = jobIterators.length;
+  let i = jobHead;
+  try {
+    for (; i < count; i++) {
+      const iterator = jobIterators[i];
+      jobIterators[i] = null;
+      runJob(iterator, jobKinds[i]);
+    }
+  }
+  finally {
+    // Mark all jobs as processed, including a possibly throwing one
+    jobHead = i < count ? i + 1 : count;
+    // If all jobs have been processed, empty the queue;
+    // array truncation via `length` does not allocate, unlike `splice`
+    if (jobHead === jobIterators.length) {
+      jobIterators.length = 0;
+      jobKinds.length = 0;
+      jobHead = 0;
+    }
+    // If a job threw, ensure a drain task exists for unprocessed jobs
+    else if (!jobDrainScheduled) {
+      jobDrainScheduled = true;
+      taskScheduler(drainJobs);
+    }
+  }
+}
+
 
 /**
   ID of the INIT state.
@@ -83,6 +179,7 @@ export const DESTROYED = 1 << 5;
 export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   protected _state: number;
   private _readable = false;
+  protected _emitReadablePending = false;
   protected _properties?: { [name: string]: any };
   protected _propertyCallbacks?: { [name: string]: [(value: any) => void] };
 
@@ -90,7 +187,7 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   constructor(initialState = OPEN) {
     super();
     this._state = initialState;
-    this.on('newListener', waitForDataListener);
+    this.on('newListener', onNewListener);
   }
 
   /**
@@ -112,7 +209,7 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
         if (!eventAsync)
           this.emit('end');
         else
-          taskScheduler(() => this.emit('end'));
+          scheduleJob(this, JOB_EMITEND);
       }
     }
     return valid;
@@ -232,7 +329,7 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
     @protected
   */
   protected _endAsync() {
-    taskScheduler(() => this._end());
+    scheduleJob(this, JOB_END);
   }
 
   /**
@@ -256,9 +353,14 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
     // Set the readable value only if it has changed
     if (this._readable !== readable) {
       this._readable = readable;
-      // If the iterator became readable, emit the `readable` event
-      if (readable)
-        taskScheduler(() => this.emit('readable'));
+      // If the iterator became readable, emit the `readable` event.
+      // Without `readable` listeners, emission is skipped:
+      // a `readable` listener that is attached later
+      // is served by the `newListener` hook instead.
+      if (readable && this.listenerCount('readable') !== 0) {
+        this._emitReadablePending = true;
+        scheduleJob(this, JOB_EMITREADABLE);
+      }
     }
   }
 
@@ -641,13 +743,22 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   }
 }
 
-// Starts emitting `data` events when `data` listeners are added
-function waitForDataListener(this: AsyncIterator<any>, eventName: string) {
+// Reacts to listeners being attached to the iterator
+function onNewListener(this: AsyncIterator<any>, eventName: string, listener: (...args: any[]) => void) {
+  // Starts emitting `data` events when `data` listeners are added
   if (eventName === 'data') {
-    this.removeListener('newListener', waitForDataListener);
+    this.removeListener('newListener', onNewListener);
     addSingleListener(this, 'readable', emitData);
     if (this.readable)
-      taskScheduler(() => emitData.call(this));
+      scheduleJob(this, JOB_EMITDATA);
+  }
+  // Since `readable` events are only scheduled when listeners are present,
+  // an iterator that became readable earlier
+  // signals its readability to newly attached listeners
+  else if (eventName === 'readable' && listener !== emitData &&
+           this.readable && !(this as any)._emitReadablePending) {
+    (this as any)._emitReadablePending = true;
+    scheduleJob(this, JOB_EMITREADABLE);
   }
 }
 // Emits new items though `data` events as long as there are `data` listeners
@@ -659,7 +770,7 @@ function emitData(this: AsyncIterator<any>) {
   // Stop draining the source if there are no more `data` listeners
   if (this.listenerCount('data') === 0 && !this.done) {
     this.removeListener('readable', emitData);
-    addSingleListener(this, 'newListener', waitForDataListener);
+    addSingleListener(this, 'newListener', onNewListener);
   }
 }
 
@@ -978,6 +1089,7 @@ export class BufferedIterator<T> extends AsyncIterator<T> {
   protected _reading = true;
   protected _pushedCount = 0;
   protected _sourceStarted: boolean;
+  protected _initAutoStart = true;
 
   /**
     Creates a new `BufferedIterator`.
@@ -988,7 +1100,8 @@ export class BufferedIterator<T> extends AsyncIterator<T> {
   constructor({ maxBufferSize = 4, autoStart = true }: BufferedIteratorOptions = {}) {
     super(INIT);
     this.maxBufferSize = maxBufferSize;
-    taskScheduler(() => this._init(autoStart));
+    this._initAutoStart = autoStart;
+    scheduleJob(this, JOB_INIT);
     this._sourceStarted = autoStart !== false;
   }
 
@@ -1166,14 +1279,11 @@ export class BufferedIterator<T> extends AsyncIterator<T> {
     Schedules `_fillBuffer` asynchronously.
   */
   protected _fillBufferAsync() {
-    // Acquire reading lock to avoid recursive reads
+    // Acquire reading lock to avoid recursive reads;
+    // the scheduled job releases the lock and calls `_fillBuffer`
     if (!this._reading) {
       this._reading = true;
-      taskScheduler(() => {
-        // Release reading lock so _fillBuffer` can take it
-        this._reading = false;
-        this._fillBuffer();
-      });
+      scheduleJob(this, JOB_FILLBUFFER);
     }
   }
 

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -180,6 +180,7 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   protected _state: number;
   private _readable = false;
   protected _emitReadablePending = false;
+  protected _flowing = false;
   protected _properties?: { [name: string]: any };
   protected _propertyCallbacks?: { [name: string]: [(value: any) => void] };
 
@@ -318,6 +319,12 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   protected _end(destroy = false) {
     if (this._changeState(destroy ? DESTROYED : ENDED)) {
       this._readable = false;
+      // Detach the flow-mode bookkeeping hook first,
+      // so the removals below do not emit `removeListener` events
+      if (this._flowing) {
+        this._flowing = false;
+        this.removeListener('removeListener', onRemoveDataListener);
+      }
       this.removeAllListeners('readable');
       this.removeAllListeners('data');
       this.removeAllListeners('end');
@@ -733,6 +740,28 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
     // An EcmaScript AsyncIterator exposes the next() function that can be invoked repeatedly
     return {
       next(): Promise<IteratorResult<T>> {
+        // If no read is pending, try to settle synchronously available results
+        // through already-resolved promises,
+        // avoiding the allocation of a promise executor and its closures
+        if (currentResolve === null) {
+          // Reject with an error that arrived while no read was pending
+          if (pendingError !== null) {
+            const error = pendingError;
+            pendingError = null;
+            removeListeners();
+            return Promise.reject(error);
+          }
+          // Signal the end of the iterator
+          if (it.done) {
+            removeListeners();
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          // Emit an item that is synchronously available
+          const value = it.read();
+          if (value !== null)
+            return Promise.resolve({ done: false, value });
+        }
+        // Await the next item, end, or error asynchronously
         return new Promise<IteratorResult<T>>((resolve, reject) => {
           currentResolve = resolve;
           currentReject = reject;
@@ -748,7 +777,12 @@ function onNewListener(this: AsyncIterator<any>, eventName: string, listener: (.
   // Starts emitting `data` events when `data` listeners are added
   if (eventName === 'data') {
     this.removeListener('newListener', onNewListener);
+    (this as any)._flowing = true;
     addSingleListener(this, 'readable', emitData);
+    // The hook cannot be attached twice:
+    // flow mode is only entered through this listener,
+    // which is only re-armed after the hook has been removed
+    this.on('removeListener', onRemoveDataListener);
     if (this.readable)
       scheduleJob(this, JOB_EMITDATA);
   }
@@ -761,17 +795,26 @@ function onNewListener(this: AsyncIterator<any>, eventName: string, listener: (.
     scheduleJob(this, JOB_EMITREADABLE);
   }
 }
-// Emits new items though `data` events as long as there are `data` listeners
-function emitData(this: AsyncIterator<any>) {
-  // While there are `data` listeners and items, emit them
-  let item;
-  while (this.listenerCount('data') !== 0 && (item = this.read()) !== null)
-    this.emit('data', item);
-  // Stop draining the source if there are no more `data` listeners
-  if (this.listenerCount('data') === 0 && !this.done) {
+// Reacts to `data` listeners being removed from the iterator:
+// when the last one is removed, the iterator leaves flow mode
+function onRemoveDataListener(this: AsyncIterator<any>, eventName: string) {
+  if (eventName === 'data' && (this as any)._flowing &&
+      this.listenerCount('data') === 0) {
+    (this as any)._flowing = false;
     this.removeListener('readable', emitData);
-    addSingleListener(this, 'newListener', onNewListener);
+    this.removeListener('removeListener', onRemoveDataListener);
+    // Wait for `data` listeners again, unless the iterator has ended
+    if (!this.done)
+      addSingleListener(this, 'newListener', onNewListener);
   }
+}
+
+// Emits new items though `data` events as long as the iterator is in flow mode.
+// The `_flowing` flag replaces a `listenerCount('data')` call per emitted item.
+function emitData(this: AsyncIterator<any>) {
+  let item;
+  while ((this as any)._flowing && (item = this.read()) !== null)
+    this.emit('data', item);
 }
 
 // Adds the listener to the event, if it has not been added previously.

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -890,12 +890,23 @@ export const DESTINATION = Symbol('destination');
 /**
  An iterator that synchronously transforms every item from its source
  by applying a mapping function.
+ Chains of synchronous transformations are fused:
+ when a `MappingIterator` is mapped or filtered again,
+ the resulting iterator reads directly from the root source
+ and applies all transformation functions in one call,
+ instead of performing a chain of nested `read` calls.
+ The intermediate iterators remain part of the pipeline
+ for event and lifecycle propagation
+ (`end`, `error`, destruction, and `destroySource` behavior).
  @extends module:asynciterator.AsyncIterator
 */
 export class MappingIterator<S, D = S> extends AsyncIterator<D> {
   protected readonly _map: MapFunction<S, D>;
   protected readonly _source: InternalSource<S>;
   protected readonly _destroySource: boolean;
+  protected readonly _root: InternalSource<any>;
+  protected readonly _chainMaps: MapFunction<any, any>[];
+  protected readonly _chainOwners: AsyncIterator<any>[];
 
   /**
    * Applies the given mapping to the source iterator.
@@ -909,6 +920,23 @@ export class MappingIterator<S, D = S> extends AsyncIterator<D> {
     this._map = map;
     this._source = ensureSourceAvailable(source);
     this._destroySource = options.destroySource !== false;
+
+    // If the source is a mapping iterator with the default read behavior,
+    // fuse both synchronous transformations into a single chain
+    // that reads straight from the root source
+    if (source instanceof MappingIterator &&
+        (source as any).read === MappingIterator.prototype.read &&
+        this.read === MappingIterator.prototype.read) {
+      this._root = source._root;
+      this._chainMaps = [...source._chainMaps, map];
+      this._chainOwners = [...source._chainOwners, this];
+    }
+    // Otherwise, this iterator starts a new chain
+    else {
+      this._root = this._source;
+      this._chainMaps = [map];
+      this._chainOwners = [this];
+    }
 
     // Close if the source is already empty
     if (source.done) {
@@ -928,14 +956,28 @@ export class MappingIterator<S, D = S> extends AsyncIterator<D> {
   read(): D | null {
     if (!this.done) {
       // Try to read an item that maps to a non-null value
-      if (this._source.readable) {
-        let item: S | null, mapped: D | null;
-        while ((item = this._source.read()) !== null) {
-          if ((mapped = this._map(item)) !== null)
-            return mapped;
+      const root = this._root;
+      if (root.readable) {
+        const maps = this._chainMaps, owners = this._chainOwners, { length } = maps;
+        let item: any;
+        while ((item = root.read()) !== null) {
+          // Apply all transformations of the fused chain,
+          // with each function bound to the iterator that created it
+          for (let i = 0; i < length && item !== null; i++)
+            item = maps[i].call(owners[i], item);
+          if (item !== null)
+            return item;
         }
       }
-      this.readable = false;
+      // Mark every iterator of the fused chain as drained,
+      // exactly as a chain of nested read() calls would have.
+      // In particular, intermediate iterators must become unreadable:
+      // otherwise, a later readable signal from the root
+      // would be swallowed by their unchanged readable state,
+      // and never reach the consumers of this iterator.
+      const owners = this._chainOwners;
+      for (let i = 0; i < owners.length; i++)
+        owners[i].readable = false;
 
       // Close this iterator if the source is empty
       if (this._source.done)

--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -394,7 +394,7 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
       // Remove _propertyCallbacks if no pending callbacks are left
       for (propertyName in propertyCallbacks)
         return;
-      delete this._propertyCallbacks;
+      this._propertyCallbacks = undefined;
     }
   }
 
@@ -760,7 +760,8 @@ export class ArrayIterator<T> extends AsyncIterator<T> {
         item = this._buffer[this._index++];
       // Close when all elements have been returned
       if (this._index === this._buffer.length) {
-        delete this._buffer;
+        // Assign instead of `delete` to keep the object's hidden class stable
+        this._buffer = undefined;
         this.close();
       }
       // Do need keep old items around indefinitely
@@ -779,7 +780,7 @@ export class ArrayIterator<T> extends AsyncIterator<T> {
 
   /* Called by {@link module:asynciterator.AsyncIterator#destroy} */
   protected _destroy(cause: Error | undefined, callback: (error?: Error) => void) {
-    delete this._buffer;
+    this._buffer = undefined;
     callback();
   }
 
@@ -949,7 +950,7 @@ export class MappingIterator<S, D = S> extends AsyncIterator<D> {
     this._source.removeListener('end', destinationClose);
     this._source.removeListener('error', destinationEmitError);
     this._source.removeListener('readable', destinationSetReadable);
-    delete this._source[DESTINATION];
+    this._source[DESTINATION] = undefined;
     if (this._destroySource)
       this._source.destroy();
     super._end(destroy);
@@ -1327,7 +1328,7 @@ export class TransformIterator<S, D = S> extends BufferedIterator<D> {
     if (isFunction(this._createSource)) {
       // Assign the source after resolving
       Promise.resolve(this._createSource()).then(source => {
-        delete this._createSource;
+        this._createSource = undefined;
         this.source = source;
         this._fillBuffer();
       }, error => this.emit('error', error));
@@ -1420,7 +1421,7 @@ export class TransformIterator<S, D = S> extends BufferedIterator<D> {
       source.removeListener('end', destinationCloseWhenDone);
       source.removeListener('error', destinationEmitError);
       source.removeListener('readable', destinationFillBuffer);
-      delete source[DESTINATION];
+      source[DESTINATION] = undefined;
       if (this._destroySource)
         source.destroy();
     }
@@ -1565,13 +1566,13 @@ export class SimpleTransformIterator<S, D = S> extends TransformIterator<S, D> {
   // Prepends items to the iterator
   protected _begin(done: () => void) {
     this._insert(this._prepender, done);
-    delete this._prepender;
+    this._prepender = undefined;
   }
 
   // Appends items to the iterator
   protected _flush(done: () => void) {
     this._insert(this._appender, done);
-    delete this._appender;
+    this._appender = undefined;
   }
 
   // Inserts items in the iterator
@@ -1763,7 +1764,7 @@ export class UnionIterator<T> extends BufferedIterator<T> {
 
     // Close immediately if done
     if (sources.done) {
-      delete this._pending;
+      this._pending = undefined;
       this.close();
     }
     // Otherwise, set up source reading
@@ -1773,7 +1774,7 @@ export class UnionIterator<T> extends BufferedIterator<T> {
         this._fillBufferAsync();
       });
       sources.on('end', () => {
-        delete this._pending;
+        this._pending = undefined;
         this._fillBuffer();
       });
     }
@@ -1842,7 +1843,7 @@ export class UnionIterator<T> extends BufferedIterator<T> {
       // Also close the sources stream if applicable
       if (this._pending) {
         this._pending!.sources!.destroy();
-        delete this._pending;
+        this._pending = undefined;
       }
     }
   }
@@ -2175,7 +2176,7 @@ export class WrappingIterator<T> extends AsyncIterator<T> {
       this._source.removeListener('end', destinationClose);
       this._source.removeListener('error', destinationEmitError);
       this._source.removeListener('readable', destinationSetReadable);
-      delete this._source[DESTINATION];
+      this._source[DESTINATION] = undefined;
 
       if (this._destroySource && isFunction(this._source.destroy))
         this._source.destroy();

--- a/test/AsyncIterator-test.js
+++ b/test/AsyncIterator-test.js
@@ -1453,20 +1453,38 @@ describe('AsyncIterator', () => {
 });
 
 describe('The internal job queue', () => {
-  function trapUncaughtException(expectedError, done) {
-    const listeners = process.listeners('uncaughtException');
+  // Temporarily traps the error of a throwing scheduled job.
+  // Depending on how the task scheduler defers tasks,
+  // such an error surfaces as an uncaught exception
+  // (queueMicrotask or setImmediate schedulers)
+  // or as an unhandled promise rejection
+  // (the promise-based fallback on Node 10, which lacks queueMicrotask).
+  function trapJobError(expectedError, done) {
+    const exceptionListeners = process.listeners('uncaughtException');
+    const rejectionListeners = process.listeners('unhandledRejection');
     process.removeAllListeners('uncaughtException');
-    process.once('uncaughtException', error => {
-      for (const listener of listeners)
-        process.on('uncaughtException', listener);
-      try {
-        error.should.equal(expectedError);
-        done();
+    process.removeAllListeners('unhandledRejection');
+    let trapped = false;
+    function onJobError(error) {
+      if (!trapped) {
+        trapped = true;
+        process.removeListener('uncaughtException', onJobError);
+        process.removeListener('unhandledRejection', onJobError);
+        for (const listener of exceptionListeners)
+          process.on('uncaughtException', listener);
+        for (const listener of rejectionListeners)
+          process.on('unhandledRejection', listener);
+        try {
+          error.should.equal(expectedError);
+          done();
+        }
+        catch (assertionError) {
+          done(assertionError);
+        }
       }
-      catch (assertionError) {
-        done(assertionError);
-      }
-    });
+    }
+    process.on('uncaughtException', onJobError);
+    process.on('unhandledRejection', onJobError);
   }
 
   describe('when an event handler of a scheduled job throws', () => {
@@ -1478,7 +1496,7 @@ describe('The internal job queue', () => {
       first.on('end', () => { throw jobError; });
       second.on('end', () => { secondEnded = true; });
 
-      trapUncaughtException(jobError, error => {
+      trapJobError(jobError, error => {
         if (error) {
           done(error);
           return;
@@ -1511,7 +1529,7 @@ describe('The internal job queue', () => {
         throw jobError;
       });
 
-      trapUncaughtException(jobError, error => {
+      trapJobError(jobError, error => {
         if (error) {
           done(error);
           return;

--- a/test/AsyncIterator-test.js
+++ b/test/AsyncIterator-test.js
@@ -1452,6 +1452,86 @@ describe('AsyncIterator', () => {
   });
 });
 
+describe('The internal job queue', () => {
+  function trapUncaughtException(expectedError, done) {
+    const listeners = process.listeners('uncaughtException');
+    process.removeAllListeners('uncaughtException');
+    process.once('uncaughtException', error => {
+      for (const listener of listeners)
+        process.on('uncaughtException', listener);
+      try {
+        error.should.equal(expectedError);
+        done();
+      }
+      catch (assertionError) {
+        done(assertionError);
+      }
+    });
+  }
+
+  describe('when an event handler of a scheduled job throws', () => {
+    it('still executes jobs that were already scheduled', done => {
+      const first = new AsyncIterator();
+      const second = new AsyncIterator();
+      const jobError = new Error('job error');
+      let secondEnded = false;
+      first.on('end', () => { throw jobError; });
+      second.on('end', () => { secondEnded = true; });
+
+      trapUncaughtException(jobError, error => {
+        if (error) {
+          done(error);
+          return;
+        }
+        // The end of the second iterator must still be processed
+        scheduleTask(() => scheduleTask(() => {
+          try {
+            secondEnded.should.equal(true);
+            done();
+          }
+          catch (assertionError) {
+            done(assertionError);
+          }
+        }));
+      });
+
+      first.close();
+      second.close();
+    });
+
+    it('still executes jobs that the throwing job scheduled', done => {
+      const first = new AsyncIterator();
+      const second = new AsyncIterator();
+      const jobError = new Error('job error');
+      let secondEnded = false;
+      second.on('end', () => { secondEnded = true; });
+      first.on('end', () => {
+        // Schedule another job before throwing
+        second.close();
+        throw jobError;
+      });
+
+      trapUncaughtException(jobError, error => {
+        if (error) {
+          done(error);
+          return;
+        }
+        scheduleTask(() => scheduleTask(() => {
+          try {
+            secondEnded.should.equal(true);
+            done();
+          }
+          catch (assertionError) {
+            done(assertionError);
+          }
+        }));
+      });
+
+      first.close();
+    });
+  });
+});
+
 describe('Type-checking functions', () => {
   describe('isPromise', () => {
     it('returns false for null', () => {

--- a/test/MappingIterator-test.js
+++ b/test/MappingIterator-test.js
@@ -1047,3 +1047,44 @@ describe('MappingIterator', () => {
     });
   });
 });
+
+describe('MappingIterator fused chains', () => {
+  describe('when the root becomes readable again after the chain drained', () => {
+    it('wakes up consumers of the outermost iterator', done => {
+      const root = new AsyncIterator();
+      let buffer = [1, 2];
+      root.read = function () {
+        if (buffer.length === 0) {
+          this.readable = false;
+          return null;
+        }
+        return buffer.shift();
+      };
+      root.readable = true;
+
+      const mapped = root.map(x => x * 10).map(x => x + 1);
+
+      // Drain all currently available items
+      const collected = [];
+      let item;
+      while ((item = mapped.read()) !== null)
+        collected.push(item);
+      collected.should.deep.equal([11, 21]);
+
+      // The `readable` event must reach the outermost iterator,
+      // even though the intermediate iterator is bypassed by fusion
+      mapped.on('readable', () => {
+        const value = mapped.read();
+        if (value !== null) {
+          value.should.equal(31);
+          mapped.destroy();
+          done();
+        }
+      });
+
+      // Make new items available on the root
+      buffer = [3];
+      root.readable = true;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

**Rollup / integration branch — do not merge directly.** This branch merges the five themed performance PRs (#2 hidden-class stability, #3 job queue + lazy readable, #5 flow flag + for-await fast path, #4 fused sync transforms, #6 setProperty allocation) with conflicts resolved, so the combined effect can be tested with one install (e.g. against Comunica). Review and merge the themed PRs; this branch then becomes redundant.

## Combined measurements vs unpatched `main`

Node v22.23.1, Linux x86_64 (2-core shared host, `nice -n 18`), 7 alternating A/B process runs, medians. Test suite: **1999 passing in both scheduler modes, coverage 100/100/100/100.**

| scenario | main wall (ms) | rollup wall (ms) | wall ratio | cpu ratio |
|---|---|---|---|---|
| 200k × `new ArrayIterator([4 items])` + destroy | 1219.9 | 77.5 | **0.06** | **0.05** |
| 100k items × 5 `.map()` + 5 `.filter()` | 59.5 | 17.0 | **0.29** | 0.27 |
| 100k items × 10 chained `.map()` | 89.3 | 28.9 | **0.32** | 0.43 |
| 1M items `data` flow drain | 150.2 | 50.5 | **0.34** | 0.39 |
| 1M items `readable`/`read()` loop | 56.4 | 25.5 | **0.45** | 0.41 |
| 200k items `for await` | 66.9 | 32.7 | **0.49** | 0.50 |
| 2-way `.clone()` of 100k items | 54.3 | 26.6 | **0.49** | 0.54 |
| `wrap()` of a 500k generator | 78.6 | 52.8 | 0.67 | 0.69 |
| 30k short-lived `.map` pipelines | 246.4 | 179.6 | **0.73** | 0.72 |
| UnionIterator 8×25k | 111.9 | 86.5 | 0.77 | 0.69 |
| MultiTransformIterator 20k×2 | 133.6 | 105.5 | 0.79 | 0.81 |
| 300k iterators × 2 `setProperty` | 275.6 | 240.9 | 0.87 | 0.88 |
| `.transform({map,offset,limit})` 100k | 61.9 | 54.7 | 0.88 | 0.89 |
| TransformIterator 50k items | 73.7 | 80.7 | ≈1* | ≈1* |

\* TransformIterator's per-item scheduled task is semantics-pinned by the test suite (each transform step observably runs in its own task); see "next steps" below.

## Downstream validation: Comunica

- **Correctness**: a join+union+filter SPARQL query over 140k triples (`query-sparql-file`) returns identical results (68,320 bindings) on this branch and on `main`; the query-shape bisection suite (single-pattern, BGP join, filter, union) is green. This smoke caught a real wakeup-propagation bug in the first version of #4, now fixed + regression-tested there.
- **Performance**: same smoke, 3 alternating pairs, post-warm runs: median cpu 5998ms → 4980ms, median wall 5792ms → 4446ms (**≈10–20% end-to-end query improvement**; 2-core shared box, noisy).
- **Real-workload shape**: in a Comunica WatDiv mixed-workload profile, asynciterator is ~9.5% of total self time, led by exactly the sites these PRs target: `setProperty` (1.15%, #6), `_end`/teardown (0.86%+, #2), `set readable` + scheduling closures (0.47%+, #3), `MappingIterator.read` (#4).

## Next steps (not in these PRs)

- `TransformIterator._read` schedules one task per transformed item; a sync trampoline breaks the per-tick observability the test suite pins. Candidate for a semver-major or an opt-in.
- `emit('data')` itself is now the dominant flow-mode cost (EventEmitter dispatch per item); bypassing it safely would require diverging from EventEmitter semantics.
- Buffer fill policy experiments (see @RubenVerborgh's 2020 `feature/performance` branch) remain unexplored under the current test contract.


**Update:** rebuilt from the updated themed branches (includes #3's Node 10 test fix). Full combined suite verified green on Node 10.24.1 and Node 22 in both scheduler modes, coverage 100/100/100/100.

---
*This PR was generated by an agent (Claude Fable 5) on @jeswr's behalf, as part of a measured performance pass over asynciterator. All numbers above were produced on-box with the stated methodology.*

> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).

