### PR TITLE
feat: add ParallelTransformIterator for in-order concurrent async mapping

### DIFF
--- a/asynciterator.ts
+++ b/asynciterator.ts
@@ -463,6 +463,25 @@ export class AsyncIterator<T> extends EventEmitter implements AsyncIterable<T> {
   }
 
   /**
+    Maps items from this iterator using an asynchronous mapping function,
+    invoking the function on multiple items concurrently
+    while emitting all results in the order of the source items.
+    After this operation, only read the returned iterator instead of the current one.
+    Because the mapping function is invoked speculatively ahead of emission,
+    it must be side-effect-free and its invocations independent of each other
+    (see {@link module:asynciterator.ParallelTransformIterator}).
+    @param {Function} map An asynchronous mapping function to call on this iterator's (remaining) items
+    @param {object} [options] Settings of the iterator
+    @param {integer} [options.concurrency=4] The maximum number of items to map concurrently
+    @param {object?} self The `this` pointer for the mapping function
+    @returns {module:asynciterator.AsyncIterator} A new iterator that maps the items from this iterator
+  */
+  parallelMap<D>(map: AsyncMapFunction<T, D>, options?: ParallelTransformOptions<T, D>,
+                 self?: any): AsyncIterator<D> {
+    return new ParallelTransformIterator<T, D>(this, { ...options, map: bind(map, self) });
+  }
+
+  /**
     Return items from this iterator that match the filter.
     After this operation, only read the returned iterator instead of the current one.
     @param {Function} filter A filter function to call on this iterator's (remaining) items
@@ -877,6 +896,12 @@ export class IntegerIterator extends AsyncIterator<number> {
  * A return value of `null` means that nothing should be emitted for a particular item.
  */
 export type MapFunction<S, D = S> = (item: S) => D | null;
+
+/**
+ * An asynchronous mapping function from one element to another.
+ * A (promise of a) return value of `null` means that nothing should be emitted for a particular item.
+ */
+export type AsyncMapFunction<S, D = S> = (item: S) => MaybePromise<D | null>;
 
 /** Function that maps an element to itself. */
 export function identity<S>(item: S): typeof item {
@@ -1712,6 +1737,177 @@ export class MultiTransformIterator<S, D = S> extends TransformIterator<S, D> {
   }
 }
 
+// Tracks an in-flight asynchronous mapping of a source item
+interface MapSlot<S, D> {
+  item: S;
+  settled: boolean;
+  value: D | null;
+  error: Error | null;
+}
+
+/**
+  An iterator that maps items from a source
+  by invoking an asynchronous mapping function
+  on multiple items concurrently,
+  while emitting all results in the order of the source items.
+  Because the mapping function is invoked speculatively
+  ahead of the item that is next in line for emission,
+  it can be invoked for items that are never emitted,
+  for instance, when the iterator is closed or destroyed early,
+  or when the mapping of a preceding item results in an error.
+  The mapping function must therefore be side-effect-free,
+  and its invocations independent of each other.
+  @extends module:asynciterator.TransformIterator
+*/
+export class ParallelTransformIterator<S, D = S> extends TransformIterator<S, D> {
+  protected _map: AsyncMapFunction<S, D> = identity as AsyncMapFunction<S, D>;
+  private _concurrency = 4;
+  private readonly _slots: LinkedList<MapSlot<S, D>> = new LinkedList();
+
+  /**
+    Creates a new `ParallelTransformIterator`.
+    @param {module:asynciterator.AsyncIterator|Readable} [source] The source this iterator generates items from
+    @param {object|Function} [options] Settings of the iterator, or the asynchronous mapping function
+    @param {integer} [options.maxBufferSize=4] The maximum number of items to keep in the buffer
+    @param {boolean} [options.autoStart=true] Whether buffering starts directly after construction
+    @param {boolean} [options.optional=false] If mapping is optional, the original item is pushed when its mapping yields `null`
+    @param {boolean} [options.destroySource=true] Whether the source should be destroyed when this transformed iterator is closed or destroyed
+    @param {module:asynciterator.AsyncIterator} [options.source] The source this iterator generates items from
+    @param {Function} [options.map] An asynchronous function to map items from the source
+    @param {integer} [options.concurrency=4] The maximum number of items to map concurrently
+  */
+  constructor(source?: SourceExpression<S>,
+              options?: ParallelTransformOptions<S, D> |
+                        ParallelTransformOptions<S, D> & AsyncMapFunction<S, D>) {
+    super(source, options as TransformIteratorOptions<S>);
+
+    // Set the mapping steps from the options
+    options = options || (!isSourceExpression(source) ? source : null as any);
+    if (options) {
+      const map = isFunction(options) ? options : options.map;
+      if (isFunction(map))
+        this._map = map;
+      if (typeof options.concurrency === 'number')
+        this.concurrency = options.concurrency;
+    }
+  }
+
+  /**
+    The maximum number of items being mapped concurrently.
+    Together with `maxBufferSize`, this determines
+    how far ahead of consumption the source is read:
+    up to `concurrency` items are being mapped
+    on top of the already mapped items in the buffer.
+    Set to `Infinity` to map all available source items simultaneously.
+    @type number
+  */
+  get concurrency() {
+    return this._concurrency;
+  }
+
+  set concurrency(concurrency) {
+    // Allow only positive integers and infinity
+    if (concurrency !== Infinity) {
+      concurrency = !Number.isFinite(concurrency) ? 4 :
+        Math.max(Math.trunc(concurrency), 1);
+    }
+    // Only set the concurrency if it changes
+    if (this._concurrency !== concurrency) {
+      this._concurrency = concurrency;
+      // Ensure sufficient items are being mapped
+      if (this._state === OPEN)
+        this._fillBuffer();
+    }
+  }
+
+  /* Tries to read and map items in parallel */
+  protected _read(count: number, done: () => void) {
+    const slots = this._slots;
+    const { source } = this;
+    let slot: MapSlot<S, D> | undefined, item: S | null;
+    do {
+      // Emit results of settled mappings, in source order
+      while (this._pushedCount < count && (slot = slots.first) && slot.settled) {
+        slots.shift();
+        // Emit a mapping error at the position of the item that caused it
+        if (slot.error !== null)
+          this.emit('error', slot.error);
+        // Skip `null` results, pushing the original item if mapping was optional
+        else if (slot.value !== null)
+          this._push(slot.value);
+        else if (this._optional)
+          this._push(slot.item as any as D);
+      }
+      // Start mapping new items until the concurrency limit is reached
+      item = null;
+      if (!this.closed && source && !source.done) {
+        while (slots.length < this._concurrency && (item = source.read()) !== null)
+          this._mapItem(item);
+      }
+      // Keep emitting if mappings have settled synchronously in the meantime
+    } while (this._pushedCount < count && (slot = slots.first) && slot.settled);
+
+    // Close when the source has ended and all results have been emitted
+    if (source && source.done && slots.empty)
+      this.close();
+    done();
+  }
+
+  /**
+    Starts the asynchronous mapping of the given item,
+    reserving a slot for its result so all results can be emitted in source order.
+    @protected
+    @param {object} item The item to map
+  */
+  protected _mapItem(item: S) {
+    const slot: MapSlot<S, D> = { item, settled: false, value: null, error: null };
+    this._slots.push(slot);
+    // Invoke the mapping function, capturing synchronous errors
+    let result;
+    try {
+      result = this._map(item);
+    }
+    catch (error) {
+      this._settleSlot(slot, null, error as Error);
+      return;
+    }
+    // Settle the slot as soon as the mapping settles
+    if (isPromise<D | null>(result)) {
+      result.then(
+        value => this._settleSlot(slot, value, null),
+        error => this._settleSlot(slot, null, error));
+    }
+    else {
+      this._settleSlot(slot, result, null);
+    }
+  }
+
+  // Stores the mapping result in its slot, and schedules emission if it is next in line
+  private _settleSlot(slot: MapSlot<S, D>, value: D | null, error: Error | null) {
+    slot.value = value;
+    slot.error = error;
+    slot.settled = true;
+    // If this result is the next to be emitted, resume filling the buffer
+    if (!this.done && this._slots.first === slot)
+      this._fillBufferAsync();
+  }
+
+  /* Closes the iterator when pending mappings are emitted. */
+  protected _closeWhenDone() {
+    // Only close when no mapping results are pending
+    if (this._slots.empty)
+      this.close();
+  }
+
+  /* Called by {@link module:asynciterator.AsyncIterator#destroy} */
+  protected _destroy(cause: Error | undefined, callback: (error?: Error) => void) {
+    // Void the results of in-flight mappings
+    this._slots.clear();
+    super._destroy(cause, callback);
+  }
+}
+
+
 /**
   An iterator that generates items by reading from multiple other iterators.
   @extends module:asynciterator.BufferedIterator
@@ -2317,6 +2513,11 @@ export interface TransformOptions<S, D> extends TransformIteratorOptions<S> {
 
 export interface MultiTransformOptions<S, D> extends TransformOptions<S, D> {
   multiTransform?: (item: S) => AsyncIterator<D>;
+}
+
+export interface ParallelTransformOptions<S, D> extends TransformIteratorOptions<S> {
+  map?: AsyncMapFunction<S, D>;
+  concurrency?: number;
 }
 
 /**

--- a/perf/ParallelTransformIterator-perf.js
+++ b/perf/ParallelTransformIterator-perf.js
@@ -1,0 +1,59 @@
+import { ArrayIterator } from '../dist/asynciterator.js';
+
+function noop() {
+  // empty function to drain an iterator
+}
+
+function run(iterator) {
+  return new Promise((resolve, reject) => {
+    iterator.on('data', noop);
+    iterator.on('error', reject);
+    iterator.on('end', resolve);
+  });
+}
+
+async function perf(createIterator, description) {
+  const now = performance.now();
+  await run(createIterator());
+  console.log(description, `${(performance.now() - now).toFixed(1)}ms`);
+}
+
+function items(count) {
+  return new ArrayIterator(new Array(count).fill(true).map((_, i) => i));
+}
+
+// Simulates an I/O-bound mapping, such as a network request
+function fetchItem(latency) {
+  return item => new Promise(resolve => setTimeout(() => resolve(item), latency));
+}
+
+(async () => {
+  // I/O-bound pipeline: 64 items, 10ms of latency per item
+  const count = 64, latency = 10;
+  await perf(() => items(count).transform({
+    transform(item, done, push) {
+      fetchItem(latency)(item).then(result => {
+        push(result);
+        done();
+      });
+    },
+  }), `${count} items x ${latency}ms sequential transform\t\t`);
+  await perf(() => items(count).parallelMap(fetchItem(latency), { concurrency: 1 }),
+    `${count} items x ${latency}ms parallelMap concurrency 1\t`);
+  await perf(() => items(count).parallelMap(fetchItem(latency), { concurrency: 4 }),
+    `${count} items x ${latency}ms parallelMap concurrency 4\t`);
+  await perf(() => items(count).parallelMap(fetchItem(latency), { concurrency: 8 }),
+    `${count} items x ${latency}ms parallelMap concurrency 8\t`);
+
+  // Hot path without latency: overhead of concurrency 1 versus a sequential transform
+  const hotCount = 1_000_000;
+  await run(items(hotCount).map(item => item)); // warm-up run
+  await perf(() => items(hotCount).transform({
+    transform(item, done, push) {
+      push(item);
+      done();
+    },
+  }), `${hotCount.toLocaleString('en')} items sequential transform\t\t`);
+  await perf(() => items(hotCount).parallelMap(item => item, { concurrency: 1 }),
+    `${hotCount.toLocaleString('en')} items parallelMap concurrency 1\t`);
+})();

--- a/test/ParallelTransformIterator-test.js
+++ b/test/ParallelTransformIterator-test.js
@@ -1,0 +1,393 @@
+import {
+  AsyncIterator,
+  BufferedIterator,
+  TransformIterator,
+  ParallelTransformIterator,
+  EmptyIterator,
+  fromArray,
+} from '../dist/asynciterator.js';
+
+import { EventEmitter } from 'events';
+
+// Resolves with the given value after the given delay
+function delayed(value, ms) {
+  return new Promise(resolve => setTimeout(() => resolve(value), ms));
+}
+
+// Rejects with the given error after the given delay
+function delayedError(error, ms) {
+  return new Promise((resolve, reject) => setTimeout(() => reject(error), ms));
+}
+
+describe('ParallelTransformIterator', () => {
+  describe('The ParallelTransformIterator function', () => {
+    describe('the result when called with `new`', () => {
+      let instance;
+      before(() => { instance = new ParallelTransformIterator(); });
+
+      it('should be a ParallelTransformIterator object', () => {
+        instance.should.be.an.instanceof(ParallelTransformIterator);
+      });
+
+      it('should be a TransformIterator object', () => {
+        instance.should.be.an.instanceof(TransformIterator);
+      });
+
+      it('should be a BufferedIterator object', () => {
+        instance.should.be.an.instanceof(BufferedIterator);
+      });
+
+      it('should be an AsyncIterator object', () => {
+        instance.should.be.an.instanceof(AsyncIterator);
+      });
+
+      it('should be an EventEmitter object', () => {
+        instance.should.be.an.instanceof(EventEmitter);
+      });
+    });
+
+    describe('the result when called through `parallelMap`', () => {
+      let instance;
+      before(() => { instance = fromArray([1, 2, 3]).parallelMap(item => Promise.resolve(item)); });
+
+      it('should be a ParallelTransformIterator object', () => {
+        instance.should.be.an.instanceof(ParallelTransformIterator);
+      });
+
+      it('should be an AsyncIterator object', () => {
+        instance.should.be.an.instanceof(AsyncIterator);
+      });
+    });
+  });
+
+  describe('A ParallelTransformIterator', () => {
+    describe('without mapping function', () => {
+      it('should emit the source items unchanged', async () => {
+        const iterator = new ParallelTransformIterator(fromArray([1, 2, 3]));
+        (await iterator.toArray()).should.deep.equal([1, 2, 3]);
+      });
+    });
+
+    describe('with an asynchronous mapping function', () => {
+      it('should emit the mapped items', async () => {
+        const iterator = fromArray([1, 2, 3, 4])
+          .parallelMap(item => Promise.resolve(item * 2));
+        (await iterator.toArray()).should.deep.equal([2, 4, 6, 8]);
+      });
+
+      it('should emit items in source order despite unequal mapping delays', async () => {
+        const items = [...new Array(16).keys()];
+        const iterator = fromArray(items)
+          .parallelMap(item => delayed(item, (item * 7) % 13), { concurrency: 4 });
+        (await iterator.toArray()).should.deep.equal(items);
+      });
+
+      it('should support a synchronously returning mapping function', async () => {
+        const iterator = fromArray([1, 2, 3])
+          .parallelMap(item => item * 10);
+        (await iterator.toArray()).should.deep.equal([10, 20, 30]);
+      });
+
+      it('should support a `this` pointer for the mapping function', async () => {
+        const self = { factor: 3 };
+        const iterator = fromArray([1, 2, 3])
+          .parallelMap(function (item) { return Promise.resolve(item * this.factor); }, {}, self);
+        (await iterator.toArray()).should.deep.equal([3, 6, 9]);
+      });
+
+      it('should skip items that map to `null`', async () => {
+        const iterator = fromArray([1, 2, 3, 4])
+          .parallelMap(item => Promise.resolve(item % 2 === 0 ? item : null));
+        (await iterator.toArray()).should.deep.equal([2, 4]);
+      });
+
+      it('should emit the original item for `null` mappings when optional', async () => {
+        const iterator = new ParallelTransformIterator(fromArray([1, 2, 3]), {
+          map: item => Promise.resolve(item === 2 ? null : item * 10),
+          optional: true,
+        });
+        (await iterator.toArray()).should.deep.equal([10, 2, 30]);
+      });
+    });
+
+    describe('created with the mapping function as options', () => {
+      it('should emit the mapped items', async () => {
+        const iterator = new ParallelTransformIterator(fromArray([1, 2, 3]),
+          item => Promise.resolve(item + 1));
+        (await iterator.toArray()).should.deep.equal([2, 3, 4]);
+      });
+    });
+
+    describe('created with only an options object', () => {
+      it('should emit the mapped items once a source is set', async () => {
+        const iterator = new ParallelTransformIterator({ map: item => Promise.resolve(item + 1) });
+        iterator.source = fromArray([1, 2, 3]);
+        (await iterator.toArray()).should.deep.equal([2, 3, 4]);
+      });
+    });
+
+    describe('created with a promise to a source', () => {
+      it('should emit the mapped items', async () => {
+        const iterator = new ParallelTransformIterator(Promise.resolve(fromArray([1, 2, 3])),
+          { map: item => Promise.resolve(item * 2) });
+        (await iterator.toArray()).should.deep.equal([2, 4, 6]);
+      });
+    });
+
+    describe('with an empty source', () => {
+      it('should end without calling the mapping function', async () => {
+        let calls = 0;
+        const iterator = new EmptyIterator()
+          .parallelMap(item => { calls++; return Promise.resolve(item); });
+        (await iterator.toArray()).should.deep.equal([]);
+        calls.should.equal(0);
+      });
+
+      it('should end on an empty array source', async () => {
+        const iterator = fromArray([]).parallelMap(item => Promise.resolve(item));
+        (await iterator.toArray()).should.deep.equal([]);
+      });
+    });
+
+    describe('without autoStart', () => {
+      it('should not start mapping until read', async () => {
+        let calls = 0;
+        const iterator = new ParallelTransformIterator(fromArray([1, 2, 3]), {
+          autoStart: false,
+          map: item => { calls++; return Promise.resolve(item); },
+        });
+        await delayed(null, 10);
+        calls.should.equal(0);
+        (await iterator.toArray()).should.deep.equal([1, 2, 3]);
+        calls.should.equal(3);
+      });
+    });
+  });
+
+  describe('The concurrency of a ParallelTransformIterator', () => {
+    it('should default to 4', () => {
+      new ParallelTransformIterator().concurrency.should.equal(4);
+    });
+
+    it('should be settable through the constructor', () => {
+      new ParallelTransformIterator(null, { concurrency: 7 }).concurrency.should.equal(7);
+    });
+
+    it('should truncate fractional values', () => {
+      const iterator = new ParallelTransformIterator();
+      iterator.concurrency = 3.7;
+      iterator.concurrency.should.equal(3);
+    });
+
+    it('should allow a minimum of 1', () => {
+      const iterator = new ParallelTransformIterator();
+      iterator.concurrency = 0;
+      iterator.concurrency.should.equal(1);
+      iterator.concurrency = -37;
+      iterator.concurrency.should.equal(1);
+    });
+
+    it('should default to 4 on invalid values', () => {
+      const iterator = new ParallelTransformIterator(null, { concurrency: 2 });
+      iterator.concurrency = NaN;
+      iterator.concurrency.should.equal(4);
+    });
+
+    it('should allow Infinity', () => {
+      const iterator = new ParallelTransformIterator();
+      iterator.concurrency = Infinity;
+      iterator.concurrency.should.equal(Infinity);
+    });
+
+    it('should not change when set to the same value', () => {
+      const iterator = new ParallelTransformIterator();
+      iterator.concurrency = 4;
+      iterator.concurrency.should.equal(4);
+    });
+
+    it('should be changeable while the iterator is open', async () => {
+      const iterator = fromArray([...new Array(6).keys()])
+        .parallelMap(item => delayed(item, 10), { concurrency: 1 });
+      await delayed(null, 5);
+      iterator.concurrency = 6;
+      iterator.concurrency.should.equal(6);
+      (await iterator.toArray()).should.deep.equal([0, 1, 2, 3, 4, 5]);
+    });
+  });
+
+  describe('A ParallelTransformIterator running mappings concurrently', () => {
+    it('should run no more mappings than the concurrency limit', async () => {
+      let active = 0, maxActive = 0;
+      const iterator = fromArray([...new Array(8).keys()])
+        .parallelMap(async item => {
+          maxActive = Math.max(maxActive, ++active);
+          const result = await delayed(item, 15);
+          active--;
+          return result;
+        }, { concurrency: 4 });
+      (await iterator.toArray()).should.deep.equal([...new Array(8).keys()]);
+      maxActive.should.equal(4);
+    });
+
+    it('should run mappings one at a time with a concurrency of 1', async () => {
+      let active = 0, maxActive = 0;
+      const items = [...new Array(6).keys()];
+      const iterator = fromArray(items)
+        .parallelMap(async item => {
+          maxActive = Math.max(maxActive, ++active);
+          const result = await delayed(item * 2, 5);
+          active--;
+          return result;
+        }, { concurrency: 1 });
+      (await iterator.toArray()).should.deep.equal(items.map(item => item * 2));
+      maxActive.should.equal(1);
+    });
+
+    it('should map all available items simultaneously with a concurrency of Infinity', async () => {
+      let active = 0, maxActive = 0;
+      const iterator = fromArray([...new Array(6).keys()])
+        .parallelMap(async item => {
+          maxActive = Math.max(maxActive, ++active);
+          const result = await delayed(item, 15);
+          active--;
+          return result;
+        }, { concurrency: Infinity });
+      (await iterator.toArray()).should.deep.equal([...new Array(6).keys()]);
+      maxActive.should.equal(6);
+    });
+
+    it('should overlap mapping delays instead of serializing them', async () => {
+      const start = Date.now();
+      const iterator = fromArray([...new Array(8).keys()])
+        .parallelMap(item => delayed(item, 15), { concurrency: 8 });
+      (await iterator.toArray()).should.deep.equal([...new Array(8).keys()]);
+      // Sequential execution would take at least 8 * 15ms = 120ms
+      (Date.now() - start).should.be.below(100);
+    });
+
+    it('should not map further ahead than the buffer and concurrency allow', async () => {
+      let calls = 0;
+      const iterator = fromArray([...new Array(100).keys()])
+        .parallelMap(item => { calls++; return Promise.resolve(item); });
+      // Wait without reading, so only the buffer and the concurrency slots may fill
+      await delayed(null, 20);
+      calls.should.be.at.most(8);
+      (await iterator.toArray()).should.have.length(100);
+      calls.should.equal(100);
+    });
+  });
+
+  describe('A ParallelTransformIterator with erroring mappings', () => {
+    it('should emit a rejection at the position of the erroring item', done => {
+      const settled = [];
+      const iterator = fromArray([0, 1, 2, 3, 4])
+        .parallelMap(item => {
+          if (item === 2)
+            return delayedError(new Error('mapping error'), 1);
+          return delayed(item, 30 - item * 5).then(result => {
+            settled.push(item);
+            return result;
+          });
+        }, { concurrency: 5 });
+      const items = [];
+      iterator.on('data', item => { items.push(item); });
+      iterator.on('error', error => {
+        error.should.have.property('message', 'mapping error');
+        // The error may only be emitted after all preceding mappings have settled
+        settled.should.include(0);
+        settled.should.include(1);
+      });
+      iterator.on('end', () => {
+        items.should.deep.equal([0, 1, 3, 4]);
+        done();
+      });
+    });
+
+    it('should emit an error when the mapping function throws synchronously', done => {
+      const iterator = fromArray([0, 1, 2])
+        .parallelMap(item => {
+          if (item === 1)
+            throw new Error('synchronous error');
+          return Promise.resolve(item);
+        });
+      const items = [];
+      iterator.on('data', item => { items.push(item); });
+      iterator.on('error', error => {
+        error.should.have.property('message', 'synchronous error');
+      });
+      iterator.on('end', () => {
+        items.should.deep.equal([0, 2]);
+        done();
+      });
+    });
+
+    it('should speculatively map items beyond an erroring item', done => {
+      const mapped = [];
+      const iterator = fromArray([0, 1, 2, 3])
+        .parallelMap(item => {
+          mapped.push(item);
+          if (item === 0)
+            return delayedError(new Error('early error'), 1);
+          return delayed(item, 10);
+        }, { concurrency: 4 });
+      iterator.on('error', () => { /* the iterator continues after an error */ });
+      iterator.on('end', () => {
+        // All items were passed to the mapping function, despite the error on the first
+        mapped.should.deep.equal([0, 1, 2, 3]);
+        done();
+      });
+      iterator.on('data', () => { /* drain */ });
+    });
+
+    it('should stop mapping new items when closed from an error listener', done => {
+      let calls = 0;
+      const iterator = fromArray([...new Array(8).keys()])
+        .parallelMap(item => {
+          calls++;
+          if (item === 0)
+            return delayedError(new Error('first error'), 1);
+          return delayed(item, 20);
+        }, { concurrency: 2 });
+      captureEvents(iterator, 'data', 'end');
+      iterator.on('error', () => { iterator.close(); });
+      setTimeout(() => {
+        calls.should.equal(2);
+        iterator.ended.should.be.true;
+        done();
+      }, 60);
+    });
+  });
+
+  describe('A ParallelTransformIterator that is destroyed', () => {
+    it('should ignore mappings that settle afterwards', done => {
+      const rejections = [];
+      const onRejection = error => { rejections.push(error); };
+      process.on('unhandledRejection', onRejection);
+
+      const iterator = fromArray([...new Array(6).keys()])
+        .parallelMap(item => item === 0 ? delayedError(new Error('late error'), 20) : delayed(item, 20),
+          { concurrency: 4 });
+      captureEvents(iterator, 'data', 'error', 'end');
+      setTimeout(() => { iterator.destroy(); }, 5);
+      setTimeout(() => {
+        process.removeListener('unhandledRejection', onRejection);
+        rejections.should.have.length(0);
+        iterator.destroyed.should.be.true;
+        iterator._eventCounts.data.should.equal(0);
+        iterator._eventCounts.error.should.equal(0);
+        iterator._eventCounts.end.should.equal(0);
+        done();
+      }, 60);
+    });
+
+    it('should destroy its source by default', done => {
+      const source = fromArray([...new Array(100).keys()]);
+      const iterator = source.parallelMap(item => delayed(item, 10));
+      setTimeout(() => { iterator.destroy(); }, 5);
+      setTimeout(() => {
+        source.done.should.be.true;
+        done();
+      }, 30);
+    });
+  });
+});


### PR DESCRIPTION
`TransformIterator` runs asynchronous transformations strictly one at a time: the next source item is only read after the previous one's `done()`, so an I/O-bound pipeline (e.g. one request per item) pays the full per-item latency serially even when the buffer has room.

This adds `ParallelTransformIterator`, exposed as `iterator.parallelMap(map, { concurrency })`, which invokes a promise-returning mapping function on up to `concurrency` items at once while still emitting all results **in source order**. Results are reordered through a queue of slots (one per in-flight mapping); the head slot is emitted as soon as it settles. Read-ahead stays bounded — new mappings start only while the buffer has room, so at most `concurrency` items are mapped on top of the `maxBufferSize` already buffered.

### Semantics
- A rejected promise (or sync throw) emits `error` at the item's **source position** — only after all preceding items' mappings settled and pushed, without dropping later results (matching the library's convention that errors don't terminate iteration).
- A `null` result skips the item (or pushes the original with `optional: true`), mirroring `MapFunction` / the `map` option.
- `destroy()` stops reading the source and voids in-flight results; late settlements are ignored and never surface as unhandled rejections.
- `concurrency: 1` degenerates exactly to the sequential behaviour.

**Caveat (documented on the class and `parallelMap`):** the mapping function runs *speculatively* ahead of emission — it may be invoked for items that are never emitted (past an error, or after an early `close()`/`destroy()`), and mappings complete out of order. So the mapper must be **side-effect-free / order-independent** (same contract as RxJS `mergeMap` / `p-map`).

### Results
- `npm test` → **2035 passing, 100% coverage** (statements/branches/functions/lines); also green under the `setImmediate` scheduler variant. `npm run lint` + `npm run build` clean.
- Benchmark, 64 items × 10 ms latency: sequential 705 ms, `concurrency:1` 709 ms (parity), **`concurrency:4` 176 ms (4.0×)**, **`concurrency:8` 88 ms (8.0×)**.
- Hot path, 1M items: sequential `transform` 626 ms vs `parallelMap` `concurrency:1` **252 ms (2.5× faster)** — `_read` drains synchronously rather than one task per item.

Draft for review — happy to adjust the API shape (`parallelMap` vs an option on `map`/`transform`), the error/`data` event-interleaving semantics in flow mode, or naming.
